### PR TITLE
Fix https download of banner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ swc_files       : "http://files.software-carpentry.org"
 swc_github      : "http://github.com/swcarpentry"
 swc_installer   : "http://files.software-carpentry.org/SWCarpentryInstaller.exe"
 swc_lessons     : "http://software-carpentry.org/v5/novice"
-swc_site        : "http://software-carpentry.org"
+swc_site        : "https://software-carpentry.org"
 swc_twitter     : "http://twitter.com/swcarpentry"
 swc_vm          : "https://docs.google.com/uc?id=0B4Kr6DYkzkQtSTZLQzF4aVB4NDQ&export=download"
 #--------------------------------------------------------------------------------


### PR DESCRIPTION
Annoyed me that the browser complains about pulling down a http (non-ssl) SWC banner.  So force to pull it from https.
